### PR TITLE
Change name and signature of the function

### DIFF
--- a/downsize.go
+++ b/downsize.go
@@ -13,8 +13,24 @@ import (
 	"github.com/nfnt/resize"
 )
 
-//Accuracy for calculating specified file size maxSize
-//for maxSize result might be in range [maxSize-Accuracy; maxSize]
+// Options are the encoding parameters.
+type Options struct {
+	// Size is desired output file size in bytes
+	Size int
+	// Format is image format to encode
+	Format string
+	// JpegOptions are the options for jpeg format
+	JpegOptions *jpeg.Options
+	// GifOptions are the options for gif format
+	GifOptions *gif.Options
+}
+
+var defaulfFormat = "jpeg"
+var defaultJpegOptions = &jpeg.Options{Quality: 100}
+var defaultOptions = &Options{Format: defaulfFormat, JpegOptions: defaultJpegOptions}
+
+//Accuracy for calculating specified file size Options.Size
+//for Options.Size result might be in range [Options.Size - Options.Size*Accuracy; Options.Size]
 const Accuracy = 0.05
 
 var bufPool = sync.Pool{
@@ -23,80 +39,83 @@ var bufPool = sync.Pool{
 	},
 }
 
-//Downsize reads image from reader r, changes size to make it <=maxSize and writes result to writer w
-func Downsize(maxSize int, r io.Reader, w io.Writer) error {
+// Encode changes size of Image m (result size<=o.Size)
+// and writes the Image m to w with the given options.
+// Default parameters are used if a nil *Options is passed.
+func Encode(w io.Writer, m image.Image, o *Options) error {
 	buf := bufPool.Get().(*bytes.Buffer)
 	buf.Reset()
 	defer bufPool.Put(buf)
 
-	originSize, err := io.Copy(buf, r)
-	if err != nil {
-		return err
+	opts := defaultOptions
+	if o != nil {
+		opts = o
+	}
+	if opts.Format == "" {
+		opts.Format = defaulfFormat
+		if opts.GifOptions != nil {
+			opts.Format = "gif"
+		}
+	}
+	if opts.Format == defaulfFormat && opts.JpegOptions == nil {
+		opts.JpegOptions = defaultJpegOptions
 	}
 
-	if int(originSize) <= maxSize {
+	if err := encode(buf, m, opts); err != nil {
+		return err
+	}
+	originSize := buf.Len()
+
+	if opts.Size <= 0 {
+		opts.Size = originSize
+	}
+
+	if int(originSize) <= opts.Size {
 		if _, err := io.Copy(w, buf); err != nil {
 			return err
 		}
 		return nil
-	}
-
-	img, format, err := image.Decode(buf)
-	if err != nil {
-		return err
 	}
 
 	buf.Reset()
 	min := 0
-	max := img.Bounds().Dx()
-	//Removing metadata by resizing with the same width
-	if err := changeWidht(max, img, format, buf); err != nil {
-		return err
-	}
-
-	noMetadataSize := buf.Len()
-	if noMetadataSize <= maxSize {
-		if _, err := io.Copy(w, buf); err != nil {
-			return err
-		}
-		return nil
-	}
+	max := m.Bounds().Dx()
 
 	for min < max {
 		buf.Reset()
 		newWidth := (min + max) / 2
-		if err := changeWidht(newWidth, img, format, buf); err != nil {
+		newm := resize.Resize(uint(newWidth), 0, m, resize.Lanczos3)
+		if err := encode(buf, newm, opts); err != nil {
 			return err
 		}
 		newSize := buf.Len()
-		if newSize > maxSize {
+		if newSize > opts.Size {
 			max = newWidth - 1
 		} else {
-			newAccur := 1 - float64(newSize)/float64(maxSize)
+			newAccur := 1 - float64(newSize)/float64(opts.Size)
 			if newAccur <= Accuracy {
 				break
 			}
 			min = newWidth + 1
 		}
 	}
-	_, err = io.Copy(w, buf)
+	_, err := io.Copy(w, buf)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func changeWidht(width int, img image.Image, format string, w io.Writer) error {
-	m := resize.Resize(uint(width), 0, img, resize.Lanczos3)
-	switch format {
+func encode(w io.Writer, m image.Image, o *Options) error {
+	switch o.Format {
 	case "jpeg":
-		jpeg.Encode(w, m, &jpeg.Options{Quality: 98})
+		jpeg.Encode(w, m, o.JpegOptions)
 	case "png":
 		png.Encode(w, m)
 	case "gif":
-		gif.Encode(w, m, nil)
+		gif.Encode(w, m, o.GifOptions)
 	default:
-		return fmt.Errorf("Unknown image format %q", format)
+		return fmt.Errorf("Unknown image format %q", o.Format)
 	}
 	return nil
 }

--- a/downsize_test.go
+++ b/downsize_test.go
@@ -2,6 +2,7 @@ package downsize
 
 import (
 	"bytes"
+	"image"
 	"os"
 	"testing"
 )
@@ -32,7 +33,12 @@ func TestDownsize(t *testing.T) {
 		defer file.Close()
 
 		resBuf := bytes.NewBuffer(nil)
-		if err = Downsize(test.maxSize, file, resBuf); err != nil {
+		img, format, err := image.Decode(file)
+		if err != nil {
+			t.Errorf("Error: %v, cannot decode file %v\n", err, test.img)
+		}
+
+		if err = Encode(resBuf, img, &Options{Size: test.maxSize, Format: format}); err != nil {
 			t.Errorf("Error: %v, cannot downsize file %v\n", err, test.img)
 		}
 		resSize := resBuf.Len()


### PR DESCRIPTION
from:
func Downsize(maxSize int, r io.Reader, w io.Writer) error
to:
func Encode(w io.Writer, m image.Image, o *Options) error

Signed-off-by: Elena Morozova <lelenanam@gmail.com>